### PR TITLE
Added in support for original 8-bit checksum as well as 16-bit crc

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -20,7 +20,7 @@ jobs:
           make
           valgrind --leak-check=full --error-exitcode=1 ./xmodem_server_test --xml-output=test-results.xml
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1.6
+        uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ if available
 ```c
 struct xmodem_server xdm;
 
-xmodem_server_init(&xdm, uart_tx_char, NULL);
+xmodem_server_init(&xdm, uart_tx_char, false, NULL);
 while (!xmodem_server_is_done(&xdm)) {
 	uint8_t resp[XMODEM_MAX_PACKET_SIZE];
 	uint32_t block_nr;

--- a/acutest.h
+++ b/acutest.h
@@ -1728,6 +1728,7 @@ main(int argc, char** argv)
     }
 
     if (test_xml_output_) {
+        double duration_total = 0;
 #if defined ACUTEST_UNIX_
         char *suite_name = basename(argv[0]);
 #elif defined ACUTEST_WIN_
@@ -1737,8 +1738,11 @@ main(int argc, char** argv)
         const char *suite_name = argv[0];
 #endif
         fprintf(test_xml_output_, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
-        fprintf(test_xml_output_, "<testsuite name=\"%s\" tests=\"%d\" errors=\"%d\" failures=\"%d\" skip=\"%d\">\n",
-            suite_name, (int)test_list_size_, test_stat_failed_units_, test_stat_failed_units_,
+        for(i = 0; test_list_[i].func != NULL; i++) {
+            duration_total += test_details_[i].duration;
+        }
+        fprintf(test_xml_output_, "<testsuite name=\"%s\" tests=\"%d\" time=\"%.2f\" errors=\"%d\" failures=\"%d\" skip=\"%d\">\n",
+            suite_name, (int)test_list_size_, duration_total, test_stat_failed_units_, test_stat_failed_units_,
             (int)test_list_size_ - test_stat_run_units_);
         for(i = 0; test_list_[i].func != NULL; i++) {
             struct test_detail_ *details = &test_details_[i];

--- a/xmodem_server.h
+++ b/xmodem_server.h
@@ -60,7 +60,8 @@ struct xmodem_server {
 	xmodem_server_state state; // What state are we in?
 	uint8_t packet_data[XMODEM_MAX_PACKET_SIZE]; // Incoming packet data
 	int packet_pos; // Where are we up to in this packet
-	uint16_t crc; // Whatis the expected CRC of the incoming packet
+	uint16_t crc; // What is the expected CRC of the incoming packet
+	bool crc_8_bit; // If using 128B packets, force the original 8-bit checksum, not 16-bit CRC
 	uint16_t packet_size; // Are we receiving 128B or 1K packets?
 	bool repeating; // Are we receiving a packet that we've already processed?
 	int64_t last_event_time; // When did we last do something interesting?
@@ -74,10 +75,11 @@ struct xmodem_server {
  * Initialise the internal xmodem server state
  * @param xdm Xmodem server state area to initialise
  * @param tx_byte callback to be called for ACK/NACK bytes
+ * @param force_8_bit_checksum if set, use original 8-bit checksum responses. If not set, use newer 16-bit CRC (XMODEM-CRC)
  * @param cb_data user-supplied pointer to be supplied to the tx_byte function
  * @return < 0 on failure, >= 0 on success
  */
-int xmodem_server_init(struct xmodem_server *xdm, xmodem_tx_byte tx_byte, void *cb_data);
+int xmodem_server_init(struct xmodem_server *xdm, xmodem_tx_byte tx_byte, bool force_8_bit_checksum, void *cb_data);
 
 /**
  * Send a single byte to the xmodem state machine

--- a/xmodem_server.h
+++ b/xmodem_server.h
@@ -61,8 +61,8 @@ struct xmodem_server {
 	uint8_t packet_data[XMODEM_MAX_PACKET_SIZE]; // Incoming packet data
 	int packet_pos; // Where are we up to in this packet
 	uint16_t crc; // What is the expected CRC of the incoming packet
-	bool crc_8_bit; // If using 128B packets, force the original 8-bit checksum, not 16-bit CRC
 	uint16_t packet_size; // Are we receiving 128B or 1K packets?
+	bool crc_8_bit; // If using 128B packets, force the original 8-bit checksum, not 16-bit CRC
 	bool repeating; // Are we receiving a packet that we've already processed?
 	int64_t last_event_time; // When did we last do something interesting?
 	uint32_t block_num; // What block are we up to?

--- a/xmodem_server_test.c
+++ b/xmodem_server_test.c
@@ -52,7 +52,7 @@ static void test_simple(void) {
 	struct xmodem_server xdm;
 	uint8_t tx_char = 0;
 
-	TEST_ASSERT(xmodem_server_init(&xdm, tx_byte, &tx_char) >= 0);
+	TEST_ASSERT(xmodem_server_init(&xdm, tx_byte, false, &tx_char) >= 0);
 	for (uint32_t i = 0; i < 5; i++) {
 		uint8_t data[128];
 		uint8_t resp[128];
@@ -74,9 +74,8 @@ static void test_simple(void) {
 static void test_errors(void) {
 	struct xmodem_server xdm;
 	uint8_t tx_char = 0;
-	int attempts = 0;
 
-	TEST_ASSERT(xmodem_server_init(&xdm, tx_byte, &tx_char) >= 0);
+	TEST_ASSERT(xmodem_server_init(&xdm, tx_byte, false, &tx_char) >= 0);
 	for (uint32_t i = 0; i < 5 && !xmodem_server_is_done(&xdm); ) {
 		uint8_t data[1024];
 		uint8_t resp[1024];
@@ -92,7 +91,6 @@ static void test_errors(void) {
 			TEST_ASSERT(block_nr == i);
 			i++;
 		}
-		attempts++;
 	}
 	xmodem_server_rx_byte(&xdm, 0x04);
 	TEST_ASSERT(xmodem_server_get_state(&xdm) == XMODEM_STATE_SUCCESSFUL);
@@ -102,7 +100,7 @@ static void test_errors(void) {
 static void test_timeout(void) {
 	struct xmodem_server xdm;
 	uint8_t tx_char = 0;
-	TEST_ASSERT(xmodem_server_init(&xdm, tx_byte, &tx_char) >= 0);
+	TEST_ASSERT(xmodem_server_init(&xdm, tx_byte, false, &tx_char) >= 0);
 
 	// Transmit 1 packet so we're not in the initial phase
 	uint8_t data[XMODEM_MAX_PACKET_SIZE] = {0};
@@ -202,7 +200,7 @@ static void test_sz(bool use_1k, size_t data_size) {
 	pid_t pid = spawn_process(args, &rd_fd, &wr_fd);
 	uint32_t block_nr;
 	TEST_ASSERT(pid >= 0);
-	TEST_ASSERT(xmodem_server_init(&xdm, tx_byte_fd, &wr_fd) >= 0);
+	TEST_ASSERT(xmodem_server_init(&xdm, tx_byte_fd, !use_1k, &wr_fd) >= 0);
 
 	while (!xmodem_server_is_done(&xdm)) {
 		fd_set rd_fds, wr_fds;


### PR DESCRIPTION
Currently we're really doing xmodem-crc, rather than the original xmodem. This adds support for the original xmodem with 8-bit checksum rather than 16-bit CRC.